### PR TITLE
nvmeof-recoverer: modify nvmeofstorage reconciler to update CRUSH Map for OSDs specified in CR

### DIFF
--- a/pkg/operator/ceph/nvmeof_recoverer/clustermanager/handler.go
+++ b/pkg/operator/ceph/nvmeof_recoverer/clustermanager/handler.go
@@ -1,0 +1,74 @@
+package clustermanager
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/coreos/pkg/capnslog"
+	"github.com/rook/rook/pkg/clusterd"
+	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var logger = capnslog.NewPackageLogger("github.com/rook/rook", "cluster-manager")
+
+func UpdateCrushMapForOSD(context *clusterd.Context, namespace, clusterName, srcHostname, devicename, destHostname string) error {
+	// Find the OSD ID for the given hostname and devicename
+	osdID, err := findOSDIDByHostAndDevice(context, namespace, srcHostname, devicename)
+	if err != nil {
+		logger.Errorf("failed to find OSD ID. targetHostname: %s, targetDeviceName: %s, err: %v", srcHostname, devicename, err)
+		return err
+	}
+
+	// Modify the CRUSH map to relocate the OSD to the destHostname
+	logger.Debugf("moving osd.%s from host %s to host %s", osdID, srcHostname, destHostname)
+	cmd := []string{"osd", "crush", "move", fmt.Sprintf("osd.%s", osdID), fmt.Sprintf("host=%s", destHostname)}
+	buf, err := executeCephCommand(context, namespace, clusterName, cmd)
+	if err != nil {
+		logger.Errorf("failed to move osd. osdID: %s, srcHost: %s, destHost: %s, err: %s", osdID, srcHostname, destHostname, string(buf))
+		return err
+	}
+	return nil
+}
+
+func findOSDIDByHostAndDevice(clusterContext *clusterd.Context, namespace, targetHostname, targetDeviceName string) (string, error) {
+	// Retrieve the complete list of OSD pods
+	pods, err := clusterContext.Clientset.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: "app=rook-ceph-osd",
+	})
+	if err != nil {
+		return "", fmt.Errorf("failed to retrieve the list of pods: %s", err)
+	}
+
+	// Find the OSD ID for the given hostname and devicename
+	for _, pod := range pods.Items {
+		// Check if the pod is running on the target hostname
+		if pod.Spec.NodeName == targetHostname {
+			for _, container := range pod.Spec.Containers {
+				for _, env := range container.Env {
+					// Check if the pod is using the target device
+					if env.Name == "ROOK_BLOCK_PATH" && env.Value == targetDeviceName {
+						osdID := pod.Labels["ceph-osd-id"]
+						return osdID, nil
+					}
+				}
+			}
+		}
+	}
+
+	return "", fmt.Errorf("no matching OSD found. targetHostname: %s, targetDevicename: %s", targetHostname, targetDeviceName)
+}
+
+func executeCephCommand(clusterContext *clusterd.Context, namespace, clusterName string, cmd []string) ([]byte, error) {
+	ctx := context.TODO()
+	clusterInfo := cephclient.AdminClusterInfo(ctx, namespace, clusterName)
+	exec := cephclient.NewCephCommand(clusterContext, clusterInfo, cmd)
+	exec.JsonOutput = true
+	buf, err := exec.Run()
+	if err != nil {
+		// TODO (cheolho.kang): Add verification to check if the result of exec.Run matches the result of 'osd crush move'. Even if 'osd crush move' is executed.
+		logger.Debugf("failed to execute ceph command. result: %s", string(buf))
+		return nil, err
+	}
+	return buf, nil
+}


### PR DESCRIPTION
This commit modifies the nvmeofstorage reconciler to update the CRUSH Map specified in the NvmeOfStorage CRs.
- Added cluster manager to update the CRUSH Map with the device detail.
- Added ```findOSDIDByHostAndDevice()``` to find the OSD ID in the Pod lists.
- Added ```executeCephCommand``` to execute the Ceph command using the ceph client.

This commit ensures that OSDs using NVMe-oF storage use virtual hosts for CRUSH Maps.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
