### PR TITLE
nvmeof-recoverer: update cluster manager to assign new host to the faulted OSD

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -5953,6 +5953,16 @@ string
 <td>
 </td>
 </tr>
+<tr>
+<td>
+<code>osdID</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="ceph.rook.io/v1.FilesystemMirrorInfoPeerSpec">FilesystemMirrorInfoPeerSpec

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -13106,6 +13106,8 @@ spec:
                         type: string
                       deviceName:
                         type: string
+                      osdID:
+                        type: string
                       port:
                         type: integer
                       subnqn:

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -13092,6 +13092,8 @@ spec:
                         type: string
                       deviceName:
                         type: string
+                      osdID:
+                        type: string
                       port:
                         type: integer
                       subnqn:

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -3232,6 +3232,7 @@ type FabricDevice struct {
 	Port         int    `json:"port"`
 	AttachedNode string `json:"attachedNode"`
 	DeviceName   string `json:"deviceName"`
+	OsdID        string `json:"osdID,omitempty"`
 }
 
 // NvmeOfStorageList contains a list of NvmeOfOSD

--- a/pkg/operator/ceph/nvmeof_recoverer/clustermanager/handler.go
+++ b/pkg/operator/ceph/nvmeof_recoverer/clustermanager/handler.go
@@ -12,12 +12,12 @@ import (
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "cluster-manager")
 
-func UpdateCrushMapForOSD(context *clusterd.Context, namespace, clusterName, srcHostname, devicename, destHostname string) error {
+func UpdateCrushMapForOSD(context *clusterd.Context, namespace, clusterName, srcHostname, devicename, destHostname string) (string, error) {
 	// Find the OSD ID for the given hostname and devicename
 	osdID, err := findOSDIDByHostAndDevice(context, namespace, srcHostname, devicename)
 	if err != nil {
 		logger.Errorf("failed to find OSD ID. targetHostname: %s, targetDeviceName: %s, err: %v", srcHostname, devicename, err)
-		return err
+		return "", err
 	}
 
 	// Modify the CRUSH map to relocate the OSD to the destHostname
@@ -26,9 +26,9 @@ func UpdateCrushMapForOSD(context *clusterd.Context, namespace, clusterName, src
 	buf, err := executeCephCommand(context, namespace, clusterName, cmd)
 	if err != nil {
 		logger.Errorf("failed to move osd. osdID: %s, srcHost: %s, destHost: %s, err: %s", osdID, srcHostname, destHostname, string(buf))
-		return err
+		return "", err
 	}
-	return nil
+	return osdID, nil
 }
 
 func findOSDIDByHostAndDevice(clusterContext *clusterd.Context, namespace, targetHostname, targetDeviceName string) (string, error) {

--- a/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/controller.go
+++ b/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/controller.go
@@ -31,13 +31,16 @@ import (
 	opcontroller "github.com/rook/rook/pkg/operator/ceph/controller"
 	"github.com/rook/rook/pkg/operator/ceph/nvmeof_recoverer/clustermanager"
 	"github.com/rook/rook/pkg/operator/ceph/reporting"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -101,6 +104,39 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 		return err
 	}
 
+	// Watch for changes on the OSD Pod object
+	podKind := source.Kind(
+		mgr.GetCache(),
+		&corev1.Pod{})
+	err = c.Watch(podKind, &handler.EnqueueRequestForObject{},
+		predicate.Funcs{
+			UpdateFunc: func(event event.UpdateEvent) bool {
+				oldPod, okOld := event.ObjectOld.(*corev1.Pod)
+				newPod, okNew := event.ObjectNew.(*corev1.Pod)
+				if !okOld || !okNew {
+					return false
+				}
+				if isOSDPod(newPod.Labels) && isPodDead(oldPod, newPod) {
+					namespacedName := fmt.Sprintf("%s/%s", newPod.Namespace, newPod.Name)
+					logger.Debugf("update event on Pod %q", namespacedName)
+					return true
+				}
+				return false
+			},
+			CreateFunc: func(e event.CreateEvent) bool {
+				return false
+			},
+			DeleteFunc: func(e event.DeleteEvent) bool {
+				return false
+			},
+			GenericFunc: func(e event.GenericEvent) bool {
+				return false
+			},
+		})
+	if err != nil {
+		return errors.Wrap(err, "failed to watch for changes on the Pod object")
+	}
+
 	return nil
 }
 
@@ -131,6 +167,10 @@ func (r *ReconcileNvmeOfStorage) reconcile(request reconcile.Request) (reconcile
 		}
 
 		return reporting.ReportReconcileResult(logger, r.recorder, request, nvmeOfStorage, reconcile.Result{}, err)
+	} else if strings.Contains(request.Name, "rook-ceph-osd") {
+		// TODO (cheolho.kang): Implement the reconclie logic later
+		// Prepare moving the OSD to another node
+		logger.Debugf("Pod %q is going be deleted", request.Name)
 	}
 
 	return reconcile.Result{}, nil
@@ -144,4 +184,28 @@ func (r *ReconcileNvmeOfStorage) fetchNvmeOfStorage(nvmeOfStorage *cephv1.NvmeOf
 		return err
 	}
 	return nil
+}
+
+func isOSDPod(labels map[string]string) bool {
+	if labels["app"] == "rook-ceph-osd" && labels["ceph-osd-id"] != "" {
+		logger.Debugf("OSD Pod found. ceph-osd-id: %s", labels["ceph-osd-id"])
+		return true
+	}
+
+	return false
+}
+
+func isPodDead(oldPod *corev1.Pod, newPod *corev1.Pod) bool {
+	namespacedName := fmt.Sprintf("%s/%s", newPod.Namespace, newPod.Name)
+	if oldPod.Status.Phase == corev1.PodRunning && newPod.Status.Phase == corev1.PodFailed {
+		logger.Infof("OSD Pod %q has transitioned from Running to Failed", namespacedName)
+		return true
+	}
+	if !oldPod.GetDeletionTimestamp().Equal(newPod.GetDeletionTimestamp()) &&
+		newPod.GetDeletionTimestamp() != nil {
+		logger.Debugf("%s is going to be deleted", namespacedName)
+		return true
+	}
+
+	return false
 }

--- a/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/controller.go
+++ b/pkg/operator/ceph/nvmeof_recoverer/nvmeofstorage/controller.go
@@ -68,6 +68,8 @@ type ReconcileNvmeOfStorage struct {
 	context          *clusterd.Context
 	opManagerContext context.Context
 	recorder         record.EventRecorder
+	clustermanager   *clustermanager.ClusterManager
+	nvmeOfStorage    *cephv1.NvmeOfStorage
 }
 
 // Add creates a new NvmeOfStorage Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -84,6 +86,8 @@ func newReconciler(mgr manager.Manager, context *clusterd.Context, opManagerCont
 		scheme:           mgr.GetScheme(),
 		opManagerContext: opManagerContext,
 		recorder:         mgr.GetEventRecorderFor("rook-" + controllerName),
+		clustermanager:   clustermanager.New(context, opManagerContext),
+		nvmeOfStorage:    &cephv1.NvmeOfStorage{},
 	}
 }
 
@@ -150,16 +154,14 @@ func (r *ReconcileNvmeOfStorage) reconcile(context context.Context, request reco
 
 	if strings.Contains(request.Name, "nvmeofstorage") {
 		// Fetch the NvmeOfStorage CRD object
-		nvmeOfStorage := &cephv1.NvmeOfStorage{}
-		err := r.fetchNvmeOfStorage(nvmeOfStorage, request)
+		err := r.fetchNvmeOfStorage(r.nvmeOfStorage, request)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
-
 		// Update the crush map with the devices in the NvmeOfStorage CR
-		for i := range nvmeOfStorage.Spec.Devices {
-			device := &nvmeOfStorage.Spec.Devices[i]
-			osdID, err := clustermanager.UpdateCrushMapForOSD(r.context, "rook-ceph", "my-cluster", device.AttachedNode, device.DeviceName, "fabric-host-"+nvmeOfStorage.Spec.Name)
+		for i := range r.nvmeOfStorage.Spec.Devices {
+			device := &r.nvmeOfStorage.Spec.Devices[i]
+			osdID, err := r.clustermanager.UpdateCrushMapForOSD("rook-ceph", "my-cluster", device.AttachedNode, device.DeviceName, "fabric-host-"+r.nvmeOfStorage.Spec.Name)
 			if err != nil {
 				logger.Debugf("failed to update CRUSH Map. targetNode: %s, targetDevice: %s, err: %s", device.AttachedNode, device.DeviceName, err)
 				continue
@@ -167,15 +169,29 @@ func (r *ReconcileNvmeOfStorage) reconcile(context context.Context, request reco
 			device.OsdID = osdID
 			logger.Debugf("successfully updated CRUSH Map. targetNode: %s, targetDevice: %s", device.AttachedNode, device.DeviceName)
 		}
-		err = r.updateCR(context, request, nvmeOfStorage)
+		err = r.updateCR(context, request, r.nvmeOfStorage)
 		if err != nil {
 			return reconcile.Result{}, err
 		}
 
-		return reporting.ReportReconcileResult(logger, r.recorder, request, nvmeOfStorage, reconcile.Result{}, err)
+		return reporting.ReportReconcileResult(logger, r.recorder, request, r.nvmeOfStorage, reconcile.Result{}, nil)
 	} else if strings.Contains(request.Name, "rook-ceph-osd") {
-		// TODO (cheolho.kang): Implement the reconclie logic later
-		// Prepare moving the OSD to another node
+		osdId, err := extractOSDID(request.Name)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		var nextHostName string
+		for _, device := range r.nvmeOfStorage.Spec.Devices {
+			if device.OsdID == osdId {
+				nextHostName = r.clustermanager.GetNextAttachableHost(device.AttachedNode)
+				if nextHostName == "" {
+					logger.Debugf("no attachable hosts found")
+					return reconcile.Result{}, nil
+				}
+				// TODO: Add create and run job for nvme-of device switch to the next host
+				// Placeholder for the job creation and execution
+			}
+		}
 		logger.Debugf("Pod %q is going be deleted", request.Name)
 	}
 
@@ -223,4 +239,14 @@ func isPodDead(oldPod *corev1.Pod, newPod *corev1.Pod) bool {
 	}
 
 	return false
+}
+
+func extractOSDID(podName string) (string, error) {
+	parts := strings.Split(podName, "-")
+	if len(parts) < 3 {
+		return "", fmt.Errorf("invalid pod name format")
+	}
+
+	osdID := parts[3]
+	return osdID, nil
 }


### PR DESCRIPTION
commit 2942a1ca58e90528201e34d2d8dd9235218594e4
Author: cheolho.kang <cheolho.kang@samsung.com>
Date:   Sun May 26 13:02:05 2024 +0000

    nvmeof-recoverer: watch for osd pod fault events
    
    this commit modifies the controller to watch for events where an osd pod transitions to a failed state or is marked for deletion.
    - added predicates to filter for osd pod death events in the watch function
    - updated reconcile logic to handle nvmeofstorage and rook-ceph-osd requests differently
    - added helper functions isOSDPod and isPodDead to detect relevant pod states
    
    the logic for reconciling rook-ceph-osd requests will be implemented in a future commit to handle updating node attachment information in the nvmeofstorage cr when an osd pod dies.
    
    Signed-off-by: cheolho.kang <cheolho.kang@samsung.com>
    
commit 507fbd721b00d4d7966cf9b2bbfe481cb8dfb783
Author: cheolho.kang <cheolho.kang@samsung.com>
Date:   Sun May 26 13:25:37 2024 +0000

    nvmeof-recoverer: add osdID field to NvmeOfStorage CRD
    
    this commit adds a new field 'osdID' to the NvmeOfStorage CRD to record the osd id assigned to a device.
    this field will be used in the nvmeofstorage controller when updating the CRUSH Map, indicating which osd id is assigned to a fabric device.
    - modified types.go to add 'osdID' to the FabricDevice struct
    
    All other files in this commit are auto-generated code.
    
    signed-off-by: cheolho.kang <cheolho.kang@samsung.com>
        

commit 513b0b56d4ea8aca901cb51586ba274562422eb6
Author: cheolho.kang <cheolho.kang@samsung.com>
Date:   Sun May 26 13:29:08 2024 +0000

    nvmeof-recoverer: update nvmeofstorage CR with assigned osdID during CRUSH map update
    
    this commit enhances the nvmeofstorage controller to update the nvmeofstorage CR with the osdID assigned to each device when modifying the CRUSH map.
    this ensures that each device's assigned osdID is recorded in the nvmeofstorage CR.
    - modified UpdateCrushMapForOSD to return osdID
    - added updateCR function to modify the nvmeofstorage CR
    - updated reconcile function to save osdID in the nvmeofstorage CR after updating the CRUSH map
    
    these changes ensure that the nvmeofstorage CR accurately reflects the osd assignments, which is crucial for handling device faults and reassignments.
    
    signed-off-by: cheolho.kang <cheolho.kang@samsung.com>


commit fe3db9f688fb44371edf87da1a63836a1e68cd70 (HEAD -> add-fault-detect, origin/add-fault-detect)
Author: cheolho.kang <cheolho.kang@samsung.com>
Date:   Sun May 26 13:41:37 2024 +0000

    nvmeof-recoverer: update cluster manager to assign new host to the faulted OSD
    
    this commit refactors the ClusterManager into a struct and add `GetNextAttachableHost` to implement fault handling.
    - convert ClusterManager to a structure with fields to manage osd to host map and the list of attachable hosts for fabric fault domain
    - added GetNextAttachableHost method for round robin allocation of new hosts when an osd pod fails
    - included nvmeOfStorage obejct in ReconcileNvmeOfStorage struct to avoid fetching the CR during every reconcile
    - modified UpdateCrushMapForOSD to maintain the osd host map and track attachable hosts
    - added extractOSDID function to extract osd id from failed pod names for hardware info lookup in nvmeOfStorage CR
    
    signed-off-by: cheolho.kang <cheolho.kang@samsung.com>

    
<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
