### PR TITLE
nvmeof-recoverer: add fast recovery logic for fault scenario

### DIFF
--- a/Documentation/CRDs/specification.md
+++ b/Documentation/CRDs/specification.md
@@ -2565,6 +2565,16 @@ string
 </tr>
 <tr>
 <td>
+<code>clusterName</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
 <code>devices</code><br/>
 <em>
 <a href="#ceph.rook.io/v1.FabricDevice">
@@ -9058,6 +9068,16 @@ string
 <tr>
 <td>
 <code>ip</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+</td>
+</tr>
+<tr>
+<td>
+<code>clusterName</code><br/>
 <em>
 string
 </em>

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -281,7 +281,7 @@ func prepareOSD(cmd *cobra.Command, args []string) error {
 		metaDevice = cfg.metadataDevice
 	}
 
-	err = osddaemon.Provision(context, agent, crushLocation, topologyAffinity, deviceFilter, metaDevice)
+	err = osddaemon.Provision(context, agent, crushLocation, topologyAffinity, deviceFilter, metaDevice, nvmeOfFaultDomain, transferOSDID)
 	if err != nil {
 		// something failed in the OSD orchestration, update the status map with failure details
 		status := oposd.OrchestrationStatus{

--- a/cmd/rook/ceph/osd.go
+++ b/cmd/rook/ceph/osd.go
@@ -68,6 +68,8 @@ var (
 	clusterName             string
 	osdID                   int
 	replaceOSDID            int
+	transferOSDID           int
+	nvmeOfFaultDomain       string
 	osdStoreType            string
 	osdStringID             string
 	osdUUID                 string
@@ -91,6 +93,8 @@ func addOSDFlags(command *cobra.Command) {
 
 	// flags specific to provisioning
 	provisionCmd.Flags().IntVar(&replaceOSDID, "replace-osd", -1, "osd to be destroyed")
+	provisionCmd.Flags().IntVar(&transferOSDID, "transfer-osd", -1, "osd to re-use for a new osd")
+	provisionCmd.Flags().StringVar(&nvmeOfFaultDomain, "nvmeof-fault-domain", "", "NVMe-oF fault domain where the OSD to be transferred is located")
 	provisionCmd.Flags().StringVar(&cfg.devices, "data-devices", "", "comma separated list of devices to use for storage")
 	provisionCmd.Flags().StringVar(&osdDataDeviceFilter, "data-device-filter", "", "a regex filter for the device names to use, or \"all\"")
 	provisionCmd.Flags().StringVar(&osdDataDevicePathFilter, "data-device-path-filter", "", "a regex filter for the device path names to use")

--- a/deploy/charts/rook-ceph/templates/resources.yaml
+++ b/deploy/charts/rook-ceph/templates/resources.yaml
@@ -13098,6 +13098,8 @@ spec:
               type: object
             spec:
               properties:
+                clusterName:
+                  type: string
                 devices:
                   items:
                     description: FabricDevice represents a fabric device connected to a node
@@ -13124,6 +13126,7 @@ spec:
                 name:
                   type: string
               required:
+                - clusterName
                 - devices
                 - ip
                 - name

--- a/deploy/examples/crds.yaml
+++ b/deploy/examples/crds.yaml
@@ -13084,6 +13084,8 @@ spec:
               type: object
             spec:
               properties:
+                clusterName:
+                  type: string
                 devices:
                   items:
                     description: FabricDevice represents a fabric device connected to a node
@@ -13110,6 +13112,7 @@ spec:
                 name:
                   type: string
               required:
+                - clusterName
                 - devices
                 - ip
                 - name

--- a/pkg/apis/ceph.rook.io/v1/types.go
+++ b/pkg/apis/ceph.rook.io/v1/types.go
@@ -3216,9 +3216,10 @@ type NvmeOfStorage struct {
 }
 
 type NvmeOfStorageSpec struct {
-	Name    string         `json:"name"`
-	IP      string         `json:"ip"`
-	Devices []FabricDevice `json:"devices"`
+	Name        string         `json:"name"`
+	IP          string         `json:"ip"`
+	ClusterName string         `json:"clusterName"`
+	Devices     []FabricDevice `json:"devices"`
 }
 
 // NvmeOfStorageStatus defines the observed state of NvmeOStorage

--- a/pkg/operator/ceph/cluster/osd/envs.go
+++ b/pkg/operator/ceph/cluster/osd/envs.go
@@ -50,6 +50,8 @@ const (
 	CrushInitialWeightVarName           = "ROOK_OSD_CRUSH_INITIAL_WEIGHT"
 	OSDStoreTypeVarName                 = "ROOK_OSD_STORE_TYPE"
 	ReplaceOSDIDVarName                 = "ROOK_REPLACE_OSD"
+	TransferOSDIDVarName                = "ROOK_TRANSFER_OSD"
+	NvmeofFaultDomainVarName            = "ROOK_NVMEOF_FAULT_DOMAIN"
 	CrushRootVarName                    = "ROOK_CRUSHMAP_ROOT"
 	tcmallocMaxTotalThreadCacheBytesEnv = "TCMALLOC_MAX_TOTAL_THREAD_CACHE_BYTES"
 )
@@ -174,6 +176,14 @@ func crushDeviceClassEnvVar(crushDeviceClass string) v1.EnvVar {
 
 func osdStoreTypeEnvVar(storeType string) v1.EnvVar {
 	return v1.EnvVar{Name: OSDStoreTypeVarName, Value: storeType}
+}
+
+func transferOSDIDEnvVar(id string) v1.EnvVar {
+	return v1.EnvVar{Name: TransferOSDIDVarName, Value: id}
+}
+
+func nvmeofFaultDomainEnvVar(host string) v1.EnvVar {
+	return v1.EnvVar{Name: NvmeofFaultDomainVarName, Value: host}
 }
 
 func replaceOSDIDEnvVar(id string) v1.EnvVar {

--- a/pkg/operator/ceph/cluster/osd/provision_spec.go
+++ b/pkg/operator/ceph/cluster/osd/provision_spec.go
@@ -305,6 +305,22 @@ func (c *Cluster) provisionOSDContainer(osdProps osdProperties, copyBinariesMoun
 	}
 
 	// Add OSD ID as environment variables.
+	// When this env is set, prepare pod job will transfer a OSD with this ID on the target node
+	if c.transferOSD != nil {
+		if !osdProps.onPVC() {
+			if c.transferOSD.Node == osdProps.crushHostname {
+				envVars = append(
+					envVars,
+					transferOSDIDEnvVar(fmt.Sprint(c.transferOSD.ID)),
+				)
+				envVars = append(
+					envVars,
+					nvmeofFaultDomainEnvVar(fmt.Sprint(c.transferOSD.FaultDomain)),
+				)
+			}
+		}
+	}
+
 	// When this env is set, prepare pod job will destroy this OSD.
 	if c.replaceOSD != nil {
 		// Compare pvc claim name in case of OSDs on PVC

--- a/pkg/operator/ceph/cluster/osd/transfer.go
+++ b/pkg/operator/ceph/cluster/osd/transfer.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2023 The Rook Authors. All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package osd for the Ceph OSDs.
+package osd
+
+const (
+	OSDTransferConfigName = "osd-transfer-config"
+	OSDTransferConfigKey  = "config"
+)
+
+type OSDTransferInfo struct {
+	ID          int    `json:"id"`
+	Node        string `json:"node"`
+	FaultDomain string `json:"faultDomain"`
+}

--- a/pkg/operator/ceph/nvmeof_recoverer/clustermanager/handler.go
+++ b/pkg/operator/ceph/nvmeof_recoverer/clustermanager/handler.go
@@ -2,29 +2,100 @@ package clustermanager
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
+	"time"
 
 	"github.com/coreos/pkg/capnslog"
 	"github.com/rook/rook/pkg/clusterd"
 	cephclient "github.com/rook/rook/pkg/daemon/ceph/client"
+	"github.com/rook/rook/pkg/operator/k8sutil"
+	batch "k8s.io/api/batch/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var logger = capnslog.NewPackageLogger("github.com/rook/rook", "cluster-manager")
 
+type NvmeofMode string
+
+// External constants used by other packages
+const (
+	NvmeofConnect    NvmeofMode = "connect"
+	NvmeofDisconnect NvmeofMode = "disconnect"
+)
+
+// Internal constants used only within this package
+const (
+	nvmeofToolCode = `
+import json
+import subprocess
+import time
+
+
+def get_nvme_devices():
+	result = subprocess.run(['nvme', 'list', '-o', 'json'],
+							stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+	devices = json.loads(result.stdout)
+	devices = {device['DevicePath'] for device in devices['Devices']}
+	return devices
+
+def connect_nvme(subnqn, ip_address, port):
+	try:
+		devices_before = get_nvme_devices()
+		subprocess.run(['nvme', 'connect', '-t', 'tcp', '-n', subnqn,
+						'-a', ip_address, '-s', port], check=True)
+		time.sleep(1)
+    except subprocess.CalledProcessError as e:
+        print('FAILED:', e)
+    finally:
+        devices_after = get_nvme_devices()
+        new_devices = [device for device in devices_after if device not in devices_before]
+        if new_devices:
+            result = '\n'.join(new_devices)
+            print('SUCCESS:', result)
+        else:
+            print('FAILED: No new devices connected.')
+
+def disconnect_nvme(subnqn):
+
+	try:
+		result = subprocess.run(['nvme', 'disconnect', '-n', subnqn],
+								stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+		output = result.stdout.strip()
+		print('SUCCESS:', output)
+	except subprocess.CalledProcessError as e:
+		print('FAILED:', e)
+
+mode = "%s"
+address = "%s"
+port = "%s"
+subnqn = "%s"
+
+if mode and subnqn and address and port:
+    if mode == 'connect':
+        connect_nvme(subnqn, address, port)
+    elif mode == 'disconnect':
+        disconnect_nvme(subnqn)
+`
+)
+
 type ClusterManager struct {
-	context         *clusterd.Context
-	OSDHostMap      map[string][]string
-	AttachableHosts []string
-	HostExists      map[string]bool
+	context          *clusterd.Context
+	opManagerContext context.Context
+	OSDHostMap       map[string][]string
+	AttachableHosts  []string
+	HostExists       map[string]bool
 }
 
-func New(context *clusterd.Context) *ClusterManager {
+func New(context *clusterd.Context, opManagerContext context.Context) *ClusterManager {
 	return &ClusterManager{
-		context:         context,
-		OSDHostMap:      make(map[string][]string),
-		HostExists:      make(map[string]bool),
-		AttachableHosts: []string{},
+		context:          context,
+		opManagerContext: opManagerContext,
+		OSDHostMap:       make(map[string][]string),
+		HostExists:       make(map[string]bool),
+		AttachableHosts:  []string{},
 	}
 }
 
@@ -111,4 +182,87 @@ func (cm *ClusterManager) GetNextAttachableHost(currentHost string) string {
 		}
 	}
 	return ""
+}
+
+func (cm *ClusterManager) StartNvmeoFConnectJob(mode NvmeofMode, targetHost, address, port, subnqn string) (string, error) {
+	privileged := true
+	job := &batch.Job{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "nvmeof-connect-job",
+			Namespace: "rook-ceph",
+		},
+		Spec: batch.JobSpec{
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "nvmeof-connect",
+				},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Name:  "nvmeof-connect",
+							Image: "quay.io/ceph/ceph:v18",
+							// TODO (cheolho.kang): Consider alternatives to the python script for attaching/detaching nvme fabric devices.
+							Command: []string{
+								"python3",
+								"-c",
+								fmt.Sprintf(nvmeofToolCode, string(mode), address, port, subnqn),
+							},
+							VolumeMounts: []v1.VolumeMount{
+								{
+									MountPath: "/dev",
+									Name:      "devices",
+								},
+							},
+							SecurityContext: &v1.SecurityContext{
+								Privileged: &privileged,
+							},
+						},
+					},
+					Volumes: []v1.Volume{
+						{
+							Name: "devices",
+							VolumeSource: v1.VolumeSource{
+								HostPath: &v1.HostPathVolumeSource{
+									Path: "/dev",
+								},
+							},
+						},
+					},
+					RestartPolicy: v1.RestartPolicyNever,
+					HostNetwork:   true,
+					NodeSelector: map[string]string{
+						"kubernetes.io/hostname": targetHost,
+					},
+				},
+			},
+		},
+	}
+
+	err := k8sutil.RunReplaceableJob(cm.opManagerContext, cm.context.Clientset, job, false)
+	if err != nil {
+		logger.Errorf("failed to run job. host: %s, err: %v", targetHost, err)
+		return "", err
+	}
+
+	err = k8sutil.WaitForJobCompletion(cm.opManagerContext, cm.context.Clientset, job, 60*time.Second)
+	if err != nil {
+		logger.Errorf("failed to wait for job completion. host: %s, err: %v", targetHost, err)
+		return "", err
+	}
+
+	// TODO(cheolho.kang): Need to improve the method of obtaining the success of the fabric device connect result and the path of the added device in the future.
+	var output string
+	output, err = k8sutil.GetPodLog(cm.opManagerContext, cm.context.Clientset, job.Namespace, fmt.Sprintf("job-name=%s", job.Name))
+	if err != nil {
+		logger.Errorf("failed to get logs. host: %s, err: %v", targetHost, err)
+		return "", err
+	}
+	if strings.HasPrefix(output, "FAILED:") {
+		return "", errors.New(output)
+	} else if strings.HasPrefix(output, "SUCCESS:") {
+		newDevice := strings.TrimSpace(strings.TrimPrefix(output, "SUCCESS:"))
+		return newDevice, nil
+	}
+
+	return output, nil
 }


### PR DESCRIPTION
- added python script to handle nvme-of device connection and disconnection
- included `opManagerContext` into the `ClusterManager` for job execution
- implemented `StartNvmeoFConnectJob()` to run the nvmeof connection job on the node
- set up job specifications with HostNetwork to ensure the job runs on the node

this change allows the system to connect nvme-oF devices to other nodes, reusing the fabric devices when an osd pod faults.

<!-- Thank you for contributing to Rook! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Review our Contributing documentation at https://rook.io/docs/rook/latest/Contributing/development-flow/
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] **Commit Message Formatting**: Commit titles and messages follow guidelines in the [developer guide](https://rook.io/docs/rook/latest/Contributing/development-flow/#commit-structure).
- [ ] Reviewed the developer guide on [Submitting a Pull Request](https://rook.io/docs/rook/latest/Contributing/development-flow/#submitting-a-pull-request)
- [ ] [Pending release notes](https://github.com/rook/rook/blob/master/PendingReleaseNotes.md) updated with breaking and/or notable changes for the next minor release.
- [ ] Documentation has been updated, if necessary.
- [ ] Unit tests have been added, if necessary.
- [ ] Integration tests have been added, if necessary.
